### PR TITLE
Improve the readability of the progress

### DIFF
--- a/rcar_flash.py
+++ b/rcar_flash.py
@@ -257,7 +257,7 @@ def send_data_with_progress(data, conn: serial.Serial, print_progress=True):
         conn.write(data[bytes_sent : bytes_sent+to_send])
         bytes_sent += to_send
         if print_progress:
-            print(f"{bytes_sent}/{total}", end="\r")
+            print(f"{bytes_sent:_}/{total:_} ({bytes_sent * 100 // total}%)", end="\r")
     if print_progress:
         # send "newline char" to start further output on the new line
         print("")


### PR DESCRIPTION
For 1MB+ files it's hard to estimate the progress
due to the long sequence of constantly changing digits.

This patch adds `_` as a separator for every three digits,
and this significantly improves visual understanding of
the progress.
Also, we print the percentage of the progress as suggested
by Volodymyr Babchuk <volodymyr_babchuk@epam.com>

So, instead of
1234567/12345678
we now see
1_234_567/12_345_678 (9%)