### PR TITLE
Allow `none` for loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,3 +407,23 @@ flash_target:
         send: const
         val: "y"
 ```
+
+### Run flash_writer only
+
+It is possible to load flash_writer only without flashing any loader.
+This may be useful if someone wants to work with flash_writer commands.
+In this case, you may specify `none` as the list of required loaders.
+In the following example, `rcar_flash` will use CPLD to switch the board
+to the download mode, load flash_writer specified for h3ulcb_4x2, and stop.
+After that, you may open your serial port and work with flash_writer.
+
+```
+sudo ./rcar_flash.py flash -c -f -b h3ulcb_4x2 -s /dev/ttyUSB0 none
+```
+
+Pay attention to the speed of the serial console. If the board supports
+SUP, then `sup_baud` will be used after loading the flash_writer.
+You may identify this by the message like
+```
+[INFO] Using serial port /dev/ttyUSB0 with baudrate 921600
+```

--- a/rcar_flash.py
+++ b/rcar_flash.py
@@ -159,7 +159,12 @@ def do_flash(conf, args):
                 if not os.path.exists(loaders[k]):
                     raise Exception(
                         f"File {loaders[k]} for loader {k} does not exists!")
-
+        elif l == "none":
+            # "none" is used when you need to upload flash_writer only
+            # without any flashing of loaders
+            if len(args.loaders) > 1:
+                raise Exception(
+                    "You can't use 'none' with any loader")
         else:
             if ':' in l:
                 idx = l.index(":")
@@ -242,7 +247,9 @@ def do_flash(conf, args):
     conn.close()
 
     log.info("All done!")
-    if args.cpld:
+    # loaders are empty if user specified "none" and this means
+    # that user wants to work with flash_writer, so we do not reset port
+    if args.cpld and loaders:
         cpld = cpld_get_instance(dev_serial, cpld_profile)
         cpld.normal_mode()
         cpld.reset()


### PR DESCRIPTION
Option `none` allows to specify that loaders should not be flashed and script should stop after uploading of flash_writer.
This may be useful in case someone wants to play with flash_writer's commands.

This PR addresses issue https://github.com/xen-troops/rcar_flash/issues/8