### PR TITLE
Use `-p` for non-default filenames

### DIFF
--- a/rcar_flash.py
+++ b/rcar_flash.py
@@ -171,7 +171,7 @@ def do_flash(conf, args):
                 ipl_name = l[:idx]
                 if ipl_name not in board["ipls"]:
                     raise Exception(f"Unknown loader name: {ipl_name}")
-                ipl_file = l[idx + 1:]
+                ipl_file = os.path.join(args.path, l[idx + 1:])
             else:
                 ipl_name = l
                 if ipl_name not in board["ipls"]:


### PR DESCRIPTION
Option `-p` is not used when a non-default filename is used for the loader. This commit fixes that.

So with this commit following command lines are equal:
```
./rcar_flash.py flash ... -p xx dummy_rtos:yy.srec
```
and
```
./rcar_flash.py flash ... dummy_rtos:xx/yy.srec
```