### PR TITLE
Remove 'dummy' prefix for v4h loaders

### DIFF
--- a/rcar_flash.yaml
+++ b/rcar_flash.yaml
@@ -471,7 +471,7 @@ board:
         file: cert_header_sa9.srec
         flash_target: s4_qspi
         flash_addr: 0x240000
-      dummy_fw:
+      fw:
         file: dummy_fw.srec
         flash_target: s4_qspi
         flash_addr: 0x280000
@@ -487,7 +487,7 @@ board:
         file: u-boot-elf-whitehawk.srec
         flash_target: s4_emmc
         flash_addr: 0xAC00
-      dummy_rtos:
+      rtos:
         file: dummy_rtos.srec
         flash_target: s4_emmc
         flash_addr: 0x0000


### PR DESCRIPTION
The "dummy' prefix is used as part of the name of the default files for 'fw' and 'rtos' loaders.
But it should not be used as the name of the loader.

Fixes: d4c860cc2d83 ("Add support for V4H Whitehawk board")