### PR TITLE
Rename some loaders for v4h

### DIFF
--- a/rcar_flash.yaml
+++ b/rcar_flash.yaml
@@ -471,11 +471,11 @@ board:
         file: cert_header_sa9.srec
         flash_target: s4_qspi
         flash_addr: 0x240000
-      fw:
+      icumx_fw:
         file: dummy_fw.srec
         flash_target: s4_qspi
         flash_addr: 0x280000
-      cr52:
+      cr52_loader:
         file: cr52_loader.srec
         flash_target: s4_qspi
         flash_addr: 0x480000
@@ -487,7 +487,7 @@ board:
         file: u-boot-elf-whitehawk.srec
         flash_target: s4_emmc
         flash_addr: 0xAC00
-      rtos:
+      cr52_fw:
         file: dummy_rtos.srec
         flash_target: s4_emmc
         flash_addr: 0x0000


### PR DESCRIPTION
The naming of some loaders is confusing. For example, `cr52` is the CR52 loader, and `rtos` is CR52 firmware.
This patch resolves the confusion and makes the naming more consistent.

Suggested-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>