### PR TITLE
Add a delay after a CPLD-related operation

### DIFF
--- a/rcar_flash.py
+++ b/rcar_flash.py
@@ -212,6 +212,9 @@ def do_flash(conf, args):
         time.sleep(0.5)
         # Need to release port, so pyserial can use it
         del cpld
+        # Let's give some time for the proper recreation
+        # of the serial device and possible udev links
+        time.sleep(1)
 
     conn = open_connection(board, args)
     # Upload flash writer if needed


### PR DESCRIPTION
In some cases, the serial device and udev rules cannot be restored fast enough after the end of the CPLD-related operations. This commit adds a 1s delay to give time for the proper setup of the serial device.