### PR TITLE
rcar_flash.yaml: remove "spider" suffix from bl31 and tee filenames

### DIFF
--- a/rcar_flash/rcar_flash.yaml
+++ b/rcar_flash/rcar_flash.yaml
@@ -420,7 +420,7 @@ board:
         flash_target: s4_qspi
       bl31:
         flash_target: s4_emmc
-        file: bl31-spider.srec
+        file: bl31.srec
         flash_addr: 0x7000
       bootparam:
         flash_target: s4_qspi
@@ -448,7 +448,7 @@ board:
         flash_addr: 0x40000
       tee:
         flash_target: s4_emmc
-        file: tee-spider.srec
+        file: tee.srec
         flash_addr: 0x7400
       u-boot:
         flash_target: s4_emmc


### PR DESCRIPTION
Yocto build now provides generic symlinks "bl31.srec" and "tee.srec" for all "S4" board variants ("Spider" and "S4SK").

This change updates the YAML config to refer to the generic filenames, making it compatible with the current deploy behavior.